### PR TITLE
Updated offers controller to new redirect path after destroy

### DIFF
--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -40,7 +40,7 @@ class OffersController < ApplicationController
   def destroy
     # @offer = Offer.find(params[:id])
     @offer.destroy
-    redirect_to @offers, notice: 'Offer was successfully destroyed.'
+    redirect_to offers_path, notice: 'Offer was successfully destroyed.'
   end
 
   private


### PR DESCRIPTION
"Updated offers controller to new redirect path after destroy"

Error before was "cannot delete nil" because it tried to redirect to the already destroyed offer show page